### PR TITLE
fix `Windows` platfrom string

### DIFF
--- a/src/utils_browser.ts
+++ b/src/utils_browser.ts
@@ -65,7 +65,7 @@ export function getBrowserHeaders(browser: Browser, productOverride?: string, pl
     }
 
     if (typeof platform === "undefined") {
-        platform = "Windows"
+        platform = "\"Windows\""
     }
     if (typeof isMobile === "undefined") {
         isMobile = false


### PR DESCRIPTION
To match Chrome browser's header value of `sec-ch-ua-platform`